### PR TITLE
ci(test): harden test workflow and add zizmor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,22 +4,43 @@ on:
     branches:
       - main
   pull_request:
+
+permissions: {}
+
 jobs:
   unittest:
     name: Unit Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: [ stable, oldstable ]
     steps:
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
 
       - name: Run unit tests
         run: go test ./...
+
+  zizmor:
+    name: Lint GitHub Actions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          inputs: .github/
+          advanced-security: false


### PR DESCRIPTION
## Description
Harden the test workflow by pinning actions to commit hashes, restricting permissions, and adding zizmor to lint GitHub Actions workflows.

## Changes
- Set `permissions: {}` at workflow level and explicit minimal permissions per job
- Pin `actions/checkout` and `actions/setup-go` to commit hashes
- Add `persist-credentials: false` to checkout steps
- Add `zizmor` job to lint GitHub Actions workflows (same setup as in trivy)

## Benefits
- Follows the principle of least privilege for workflow permissions
- Pinned actions prevent supply chain attacks via tag mutation
- `persist-credentials: false` limits credential exposure
- `zizmor` catches security issues in workflows on every PR